### PR TITLE
Remove typedoc-plugin keyword

### DIFF
--- a/packages/typedoc/package.json
+++ b/packages/typedoc/package.json
@@ -40,7 +40,6 @@
     "plugin",
     "enio",
     "enio.ai",
-    "typedoc-plugin",
     "monorepo",
     "documentation",
     "typescript",


### PR DESCRIPTION
This keyword is used by TypeDoc to automatically discover and load plugins by default. If this package is installed, this will result in errors when running TypeDoc since `require("@enio.ai/typedoc").load` is not a function.