### PR TITLE
Nx clone - Correctly replace directory and name references

### DIFF
--- a/packages/nx-clone/CHANGELOG.md
+++ b/packages/nx-clone/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.1.3](https://github.com/enio-ireland/enio/compare/nx-clone-0.1.2...nx-clone-0.1.3) (2023-03-05)
+
+
+### Bug Fixes
+
+* **nx-clone:** determine correct files to update ([c0431c7](https://github.com/enio-ireland/enio/commit/c0431c757685034a8b1e17f7faffbab5d8dc6e7b))
+
+
+### Reverts
+
+* **nx-clone:** drop tslib@2.5.0 in favor of current version used by nx ([9971434](https://github.com/enio-ireland/enio/commit/9971434f752f2c35ce8d96d9f6521b525280c90b))
+
 ## [0.1.2](https://github.com/enio-ireland/enio/compare/nx-clone-0.1.1...nx-clone-0.1.2) (2023-03-05)
 
 ## [0.1.1](https://github.com/enio-ireland/enio/compare/nx-clone-0.1.0...nx-clone-0.1.1) (2023-03-05)

--- a/packages/nx-clone/package-lock.json
+++ b/packages/nx-clone/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@enio.ai/nx-clone",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@enio.ai/nx-clone",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "funding": [
         {
           "type": "github",

--- a/packages/nx-clone/package-lock.json
+++ b/packages/nx-clone/package-lock.json
@@ -16,7 +16,7 @@
       "license": "MIT",
       "dependencies": {
         "@nrwl/devkit": "^15.8.5",
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/packages/nx-clone/package.json
+++ b/packages/nx-clone/package.json
@@ -14,7 +14,7 @@
   "private": false,
   "dependencies": {
     "@nrwl/devkit": "^15.8.5",
-    "tslib": "^2.5.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {},
   "contributors": [

--- a/packages/nx-clone/package.json
+++ b/packages/nx-clone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enio.ai/nx-clone",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Generator to instantly replicate your favorite custom Nx projects.",
   "license": "MIT",
   "author": "Enio Authors",

--- a/packages/nx-install/CHANGELOG.md
+++ b/packages/nx-install/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.2.3](https://github.com/enio-ireland/enio/compare/nx-install-0.2.2...nx-install-0.2.3) (2023-03-05)
+
+
+### Reverts
+
+* **nx-install:** drop tslib@2.5.0 in favor of current version used by nx ([0d07ee1](https://github.com/enio-ireland/enio/commit/0d07ee15f4bdf48ae984dbee985535e850750da4))
+
 ## [0.2.2](https://github.com/enio-ireland/enio/compare/nx-install-0.2.1...nx-install-0.2.2) (2023-03-05)
 
 ## [0.2.1](https://github.com/enio-ireland/enio/compare/nx-install-0.2.0...nx-install-0.2.1) (2023-01-02)

--- a/packages/nx-install/package-lock.json
+++ b/packages/nx-install/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@enio.ai/nx-install",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@enio.ai/nx-install",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "funding": [
         {
           "type": "github",

--- a/packages/nx-install/package-lock.json
+++ b/packages/nx-install/package-lock.json
@@ -16,7 +16,7 @@
       "license": "MIT",
       "dependencies": {
         "@nrwl/devkit": "^15.8.5",
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/packages/nx-install/package.json
+++ b/packages/nx-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enio.ai/nx-install",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Generator to setup command to install dependencies through npm for each project",
   "license": "MIT",
   "author": "Enio Authors",

--- a/packages/nx-install/package.json
+++ b/packages/nx-install/package.json
@@ -14,7 +14,7 @@
   "private": false,
   "dependencies": {
     "@nrwl/devkit": "^15.8.5",
-    "tslib": "^2.5.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {},
   "contributors": [

--- a/packages/typedoc/CHANGELOG.md
+++ b/packages/typedoc/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [1.0.8](https://github.com/enio-ireland/enio/compare/typedoc-1.0.7...typedoc-1.0.8) (2023-03-05)
+
+
+### Reverts
+
+* **typedoc:** drop tslib@2.5.0 in favor of current version used by nx ([748c421](https://github.com/enio-ireland/enio/commit/748c421683fe5dd563b62de2dcccd568d30358ea))
+
 ## [1.0.7](https://github.com/enio-ireland/enio/compare/typedoc-1.0.6...typedoc-1.0.7) (2023-03-05)
 
 ## [1.0.6](https://github.com/enio-ireland/enio/compare/typedoc-1.0.5...typedoc-1.0.6) (2023-01-15)

--- a/packages/typedoc/package-lock.json
+++ b/packages/typedoc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@enio.ai/typedoc",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@enio.ai/typedoc",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "funding": [
         {
           "type": "github",

--- a/packages/typedoc/package-lock.json
+++ b/packages/typedoc/package-lock.json
@@ -16,7 +16,7 @@
       "license": "MIT",
       "dependencies": {
         "@nrwl/devkit": "^15.8.5",
-        "tslib": "^2.5.0"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
         "typedoc": "^0.23.26",

--- a/packages/typedoc/package.json
+++ b/packages/typedoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enio.ai/typedoc",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Generator to setup Nx projects with documentation automation using typedoc",
   "license": "MIT",
   "author": "Enio Authors",

--- a/packages/typedoc/package.json
+++ b/packages/typedoc/package.json
@@ -14,7 +14,7 @@
   "private": false,
   "dependencies": {
     "@nrwl/devkit": "^15.8.5",
-    "tslib": "^2.5.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "typedoc": "^0.23.26",


### PR DESCRIPTION
* Drop the latest tslib requirement to make it easier to work with the latest nx workspace
* Fix the issue with nx-clone where it did not do all project replacements